### PR TITLE
Feat: docs buttons

### DIFF
--- a/docs/buttons/button-circle.mdx
+++ b/docs/buttons/button-circle.mdx
@@ -1,1 +1,65 @@
-Button Circle
+---
+product: dd360-ds
+title: React Button Circle component
+components: BaseCircleButton
+---
+
+# ButtonCircle
+
+    The ButtonCircle component is a circular button that can be customized with different variants and alignment options.
+    It can be used for various functionalities, such as displaying options for actions to be performed by the user.
+
+### Import
+
+<WindowEditor codeString="import { BaseCircleButton } from 'dd360-ds'" />
+<WindowEditor codeString="import BaseCircleButton from 'dd360-ds/BaseCircleButton'" />
+
+### Usage
+
+The basic usage of the ButtonCircle component can be performed as follows:
+```tsx
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100">
+    <BaseCircleButton />
+</Container>
+```
+
+<WindowEditor codeString="<BaseCircleButton />" />
+
+#### Circle
+
+You can also use the "circle" variant to get a circle button:
+```tsx
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100">
+    <BaseCircleButton variant="circle" />
+</Container>
+```
+
+<WindowEditor
+    codeString="import { BaseCircleButton } from 'dd360-ds'
+ <BaseCircleButton variant='circle' />"
+/>
+
+#### BaseCircleButton with custom icon
+
+In addition, you can customize the buttons using custom icons:
+```tsx
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100">
+    <BaseCircleButton icon={<DynamicHeroIcon icon="AcademicCapIcon" className="text-blue-700 w-6" />} />
+</Container>
+```
+
+<WindowEditor codeString="import { BaseCircleButton } from 'dd360-ds'
+import DynamicHeroIcon from 'dd360-ds/DynamicHeroIcon'
+
+<BaseCircleButton icon={<DynamicHeroIcon icon='AcademicCapIcon' className='text-blue-700 w-6' />} />"
+/>
+
+### API Reference
+
+<CustomTableDocs
+    dataTable={[
+        { title: 'variant', default: 'square', types: ['square', 'circle'] },
+        { title: 'align', default: 'start', types: ['start', 'end', 'center', 'baseline', 'stretch'] },
+        { title: 'icon', default: null, types: ['ReactNode'] }
+    ]}
+/>

--- a/docs/buttons/button-group.mdx
+++ b/docs/buttons/button-group.mdx
@@ -1,1 +1,63 @@
-Button Group
+---
+product: dd360-ds
+title: React Button Group component
+components: ButtonGroup
+---
+
+# ButtonGroup
+
+    ButtonGroup is a component that groups multiple Button components together.
+
+## Imports
+
+<WindowEditor codeString="import { ButtonGroup } from 'dd360-ds'" />
+<WindowEditor codeString="import ButtonGroup from 'dd360-ds/ButtonGroup'" />
+
+### Usage
+
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100">
+    <ButtonGroup>
+        <Button>1st button</Button>
+        <Button>2nd button</Button>
+    </ButtonGroup>
+</Container>
+
+<WindowEditor
+    codeString="import { Button, ButtonGroup } from 'dd360-ds'
+
+    <ButtonGroup>
+    &nbsp;&nbsp;<Button>1st button</Button>
+    &nbsp;&nbsp;<Button>2nd button</Button>
+    </ButtonGroup>" />
+
+#### Props
+
+You can also customize the alignment, gap, and orientation of the buttons within the group using the props "orientation", "align", and "gap".
+
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100">
+    <ButtonGroup orientation="horizontal" align="start" gap={6}>
+        <Button variant="primary">1st button</Button>
+        <Button variant="secondary">2nd button</Button>
+        <Button variant="success">3rd button</Button>
+    </ButtonGroup>
+</Container>
+
+<WindowEditor
+    codeString="import { Button, ButtonGroup } from 'dd360-ds'
+
+    <ButtonGroup orientation='horizontal' align='start' gap={6}>
+    &nbsp;&nbsp;<Button variant='primary'>1st button</Button>
+    &nbsp;&nbsp;<Button variant='secondary'>2nd button</Button>
+    &nbsp;&nbsp;<Button variant='success'>3rd button</Button>
+    </ButtonGroup>" />
+
+### API Reference
+
+<CustomTableDocs
+    dataTable={[
+        { title: 'orientation', default: 'vertical', types: ['vertical', 'horizontal'] },
+        { title: 'align', default: 'start', types: ['start', 'end', 'center', 'baseline', 'stretch'] },
+        { title: 'gap', default: '6', types: ['number'] },
+        { title: 'className', default: null, types: ['string'] }
+    ]}
+/>

--- a/docs/buttons/button-radio-group.mdx
+++ b/docs/buttons/button-radio-group.mdx
@@ -1,1 +1,50 @@
-Button radio group
+---
+product: dd360-ds
+title: React Radio Group component
+components: RadioGroup
+---
+
+# RadioGroup
+
+RadioGroup is a component that allows you to group multiple Radio components together.
+
+### Import
+
+To import the RadioGroup component, use the following syntax:
+
+<WindowEditor codeString="import { RadioGroup } from 'dd360-ds'" />
+<WindowEditor codeString="import RadioGroup from 'dd360-ds/RadioGroup'" />
+
+### Usage
+
+The RadioGroup component requires the "value" prop to be set. Here's an example of how to use the RadioGroup component:
+
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100">
+    <RadioGroup name="radio-buttons-group" onChange={() => {}} title="RadioGroup" value="A" className="gap-x-4" row>
+        <Radio label="Lorem A" value="A" className="cursor-pointer -mb-0" />
+        <Radio label="Lorem B" value="B" className="cursor-pointer -mb-0" />
+    </RadioGroup>
+</Container>
+
+<WindowEditor
+    codeString="import {RadioGroup, Radio} from 'dd360-ds'
+    
+<RadioGroup name='radio-buttons-group' title='RadioGroup' value='A' row>
+    <Radio label='Lorem A' value='A' />
+    <Radio label='Lorem B' value='B' />
+</RadioGroup>
+"
+/>
+
+### API Reference
+
+<CustomTableDocs
+    dataTable={[
+        { title: 'value', default: null, types: ['string'], required: true },
+        { title: 'title', default: null, types: ['string'] },
+        { title: 'name', default: null, types: ['string'] },
+        { title: 'onChange', default: null, types: ['((event: ChangeEvent<HTMLInputElement>) => void)'] },
+        { title: 'row', default: 'false', types: ['boolean'] },
+        { title: 'className', default: null, types: ['string'] }
+    ]}
+/>

--- a/docs/buttons/button-radio.mdx
+++ b/docs/buttons/button-radio.mdx
@@ -1,1 +1,141 @@
-Button radio
+---
+product: dd360-ds
+title: React Radio component
+components: Radio
+---
+
+# Radio
+
+The Radio Button component is a type of button that allows the user to select a single option from a set of predefined options.
+
+### Import
+
+To import the Radio Button component, use the following syntax:
+
+<WindowEditor codeString="import { Radio } from 'dd360-ds'" />
+<WindowEditor codeString="import Radio from 'dd360-ds/Radio'" />
+
+### Usage
+
+The prop value is mandatory and is used to indicate the value of the selected option
+
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100">
+    <Radio onChange={() => {}} value="one" className="cursor-pointer -mb-0" />
+</Container>
+
+<WindowEditor
+    codeString="import { Radio } from 'dd360-ds'
+
+    <Radio value='one' />"
+/>
+
+#### Label
+
+To add a label to the radio button, you can use the prop label:
+
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100">
+    <Radio onChange={() => {}} value="one" label="Click here" className="cursor-pointer -mb-0" />
+</Container>
+
+<WindowEditor
+    codeString="import { Radio } from 'dd360-ds'
+
+    <Radio value='one' label='Click here' />"
+
+/>
+
+#### Checked
+
+To display the selected state of the radio button, the checked prop can be used:
+
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100">
+    <Radio onChange={() => {}} value="one" label='Click here' checked className="cursor-pointer -mb-0" />
+</Container>
+
+<WindowEditor
+    codeString="import { Radio } from 'dd360-ds'
+
+    <Radio value='one' checked label='Click here' />"
+
+/>
+
+#### Disabled
+
+To disable the radio button, the disabled prop can be used:
+
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100">
+    <Radio onChange={() => {}} value="one" label='Click here' disabled className="-mb-0" />
+</Container>
+
+<WindowEditor
+    codeString="import { Radio } from 'dd360-ds'
+
+    <Radio value='one' disabled label='Click here' />"
+
+/>
+
+#### Error
+
+To display a radio button with error status, the prop error can be used:
+
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100">
+    <Radio onChange={() => {}} value="one" checked label='Click here' error className="cursor-pointer -mb-0" />
+</Container>
+
+<WindowEditor
+    codeString="import { Radio } from 'dd360-ds'
+
+    <Radio value='one' error label='Click here' checked />"
+
+/>
+
+#### Colors
+
+The Radio Button component comes with predefined colors. By default, it uses the primary variant, but the following colors can also be used: success, danger and
+primary:
+
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100 flex align-center gap-x-4">
+    <Radio onChange={() => {}} value="one" label='Click here' color="primary" checked className="cursor-pointer -mb-0" />
+    <Radio onChange={() => {}} value="two" label='Click here' color="success" checked className="cursor-pointer -mb-0" />
+    <Radio onChange={() => {}} value="three" label='Click here' color="danger" checked className="cursor-pointer -mb-0" />
+</Container>
+
+<WindowEditor
+    codeString="import { Radio, RadioGroup } from 'dd360-ds'
+      <RadioGroup name='radio-buttons-group' title='Radio Group' row >
+      &nbsp;&nbsp;<Radio value='one' label='Click here' color='primary' checked />
+      &nbsp;&nbsp;<Radio value='two' label='Click here' color='success' checked />
+      &nbsp;&nbsp;<Radio value='three' label='Click here' color='danger' checked />
+      </RadioGroup>"
+/>
+
+#### InputProps
+
+The inputProps property allows passing additional InputHTMLAttributes to the Radio component:
+
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100">
+    <Radio value='one' label="Click here" inputProps={{ 'aria-label': 'one'}} onChange={() => {}}  className="cursor-pointer -mb-0" />
+</Container>
+
+<WindowEditor
+    codeString="import { Radio } from 'dd360-ds'
+    <Radio value='one' inputProps={{ 'aria-label': 'one'}} label='Click here' />"
+/>
+
+### API Reference
+
+<CustomTableDocs
+    dataTable={[
+        { title: 'value', default: null, types: ['string'], required: true },
+        { title: 'label', default: null, types: ['string'] },
+        { title: 'name', default: null, types: ['string'] },
+        { title: 'color', default: 'primary', types: ['primary', 'success', 'danger'] },
+        { title: 'disabled', default: 'false', types: ['boolean'] },
+        { title: 'checked', default: 'false', types: ['boolean'] },
+        { title: 'error', default: 'false', types: ['boolean'] },
+        { title: 'className', default: null, types: ['string'] },
+        { title: 'onChange', default: null, types: ['((event: ChangeEvent<HTMLInputElement>) => void)'] },
+        { title: 'inputProps', default: null, types: ['InputHTMLAttributes'] },
+        { title: 'style', default: null, types: ['CSSProperties'] }
+    ]}
+/>

--- a/docs/buttons/button.mdx
+++ b/docs/buttons/button.mdx
@@ -1,341 +1,159 @@
-# Button
-## heading2
-### heading3
-#### heading4
-##### heading5
+---
+product: dd360-ds
+title: React Button component
+components: Button
+---
 
 # Button
 
-A demo component for DD360 products.
+     button indicates a distinct action and executes a function. Text, icon, or a combination of the two express the action and are supported by the variant and occasionally a tooltip.
 
-A button indicates a distinct action and executes a function. Text, icon, or a combination of the two express the action and are supported by the variant and occasionally a tooltip.
+## Imports
 
-## Import
+    <WindowEditor codeString="import { Button } from 'dd360-ds' " />
+    <WindowEditor codeString="import Button from 'dd360-ds/Buttons'" />
 
-<WindowEditor className="mb-4" language="tsx" codeString={`import React from "react"
-import { Button } from "dd360-ds"`} />
+### Usage
 
-## Usage example
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100 w-fit">
+    <Button>Click Me</Button>
+</Container>
 
-<WindowEditor className="mb-4" language="tsx" codeString={`import React from "react"
-import { Button } from "dd360-ds"
+<WindowEditor
+    codeString="import { Button } from 'dd360-ds'
 
-<Button 
-  onClick={function noRefCheck(){}} 
-  variant="primary">
-  Comprar
-</Button>`} />
+    <Button>Click me</Button>"
+/>
 
-## API Reference
+##### Variants
 
-<Table>
-    <Table.Header>
-        <Table.HeaderRow>
-            <Table.HeaderCell style={{ minWidth: 150 }}>Name</Table.HeaderCell>
-            <Table.HeaderCell style={{ minWidth: 150 }}>Description</Table.HeaderCell>
-            <Table.HeaderCell style={{ minWidth: 150 }}>Default</Table.HeaderCell>
-            <Table.HeaderCell style={{ minWidth: 150 }}>
-                <div className="flex justify-between items-center">
-                    <span>Control</span>
-                    <Button varian="outline">Reset</Button>
-                </div>
-            </Table.HeaderCell>
-        </Table.HeaderRow>
-    </Table.Header>
-    <Table.Body>
-        <Table.Row >
-            <Table.Cell className="py-4">variant</Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="grid grid-cols-3 gap-2" style={{ width: 'fit-content' }}>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"primary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"secondary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"tertiary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"outline"</div>
-                </div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <Select
-                        variant="outlined"
-                        rounded="lg"
-                        optionsList={{
-                            disabled: {
-                                label: 'elige una opcion',
-                                disabled: true
-                            },
-                            primary: {
-                                label: 'Primary'
-                            },
-                            secondary: {
-                                label: 'Secondary'
-                            },
-                            tertiary: {
-                                label: 'tertiary',
-                            }
-                        }}
-                    />
-            </Table.Cell>
-        </Table.Row>
-        <Table.Row >
-            <Table.Cell className="py-4">Children</Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="grid grid-cols-3 gap-2" style={{ width: 'fit-content' }}>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"primary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"secondary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"tertiary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"outline"</div>
-                </div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <Select
-                        variant="outlined"
-                        rounded="lg"
-                        optionsList={{
-                            disabled: {
-                                label: 'elige una opcion',
-                                disabled: true
-                            },
-                            primary: {
-                                label: 'Primary'
-                            },
-                            secondary: {
-                                label: 'Secondary'
-                            },
-                            tertiary: {
-                                label: 'tertiary',
-                            }
-                        }}
-                    />
-            </Table.Cell>
-        </Table.Row>
-        <Table.Row >
-            <Table.Cell className="py-4">onClick</Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="grid grid-cols-3 gap-2" style={{ width: 'fit-content' }}>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"primary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"secondary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"tertiary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"outline"</div>
-                </div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <Select
-                        variant="outlined"
-                        rounded="lg"
-                        optionsList={{
-                            disabled: {
-                                label: 'elige una opcion',
-                                disabled: true
-                            },
-                            primary: {
-                                label: 'Primary'
-                            },
-                            secondary: {
-                                label: 'Secondary'
-                            },
-                            tertiary: {
-                                label: 'tertiary',
-                            }
-                        }}
-                    />
-            </Table.Cell>
-        </Table.Row>
-        <Table.Row >
-            <Table.Cell className="py-4">Size</Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="grid grid-cols-3 gap-2" style={{ width: 'fit-content' }}>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"primary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"secondary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"tertiary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"outline"</div>
-                </div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <Select
-                        variant="outlined"
-                        rounded="lg"
-                        optionsList={{
-                            disabled: {
-                                label: 'elige una opcion',
-                                disabled: true
-                            },
-                            primary: {
-                                label: 'Primary'
-                            },
-                            secondary: {
-                                label: 'Secondary'
-                            },
-                            tertiary: {
-                                label: 'tertiary',
-                            }
-                        }}
-                    />
-            </Table.Cell>
-        </Table.Row>
-        <Table.Row >
-            <Table.Cell className="py-4">Disabled</Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="grid grid-cols-3 gap-2" style={{ width: 'fit-content' }}>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"primary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"secondary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"tertiary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"outline"</div>
-                </div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <Select
-                        variant="outlined"
-                        rounded="lg"
-                        optionsList={{
-                            disabled: {
-                                label: 'elige una opcion',
-                                disabled: true
-                            },
-                            primary: {
-                                label: 'Primary'
-                            },
-                            secondary: {
-                                label: 'Secondary'
-                            },
-                            tertiary: {
-                                label: 'tertiary',
-                            }
-                        }}
-                    />
-            </Table.Cell>
-        </Table.Row>
-        <Table.Row >
-            <Table.Cell className="py-4">isLoading</Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="grid grid-cols-3 gap-2" style={{ width: 'fit-content' }}>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"primary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"secondary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"tertiary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"outline"</div>
-                </div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="flex gap-4 items-center">
-                    <Switch setToggle={() => {}} toggle />
-                    <Text bold size="base">True</Text>
-                </div>
-            </Table.Cell>
-        </Table.Row>
-        <Table.Row >
-            <Table.Cell className="py-4">ClassName</Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="grid grid-cols-3 gap-2" style={{ width: 'fit-content' }}>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"primary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"secondary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"tertiary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"outline"</div>
-                </div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="flex gap-4 items-center">
-                    <Switch setToggle={() => {}} />
-                    <Text bold size="base">False</Text>
-                </div>
-            </Table.Cell>
-        </Table.Row>
-        <Table.Row>
-            <Table.Cell className="py-4">Padding</Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="grid grid-cols-3 gap-2" style={{ width: 'fit-content' }}>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"primary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"secondary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"tertiary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"outline"</div>
-                </div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <Select
-                        variant="outlined"
-                        rounded="lg"
-                        optionsList={{
-                            disabled: {
-                                label: 'Choose option...',
-                                disabled: true
-                            },
-                            primary: {
-                                label: 'Primary'
-                            },
-                            secondary: {
-                                label: 'Secondary'
-                            },
-                            tertiary: {
-                                label: 'tertiary',
-                            }
-                        }}
-                    />
-            </Table.Cell>
-        </Table.Row>
-        <Table.Row>
-            <Table.Cell className="py-4">fontWeight</Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="grid grid-cols-3 gap-2" style={{ width: 'fit-content' }}>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"primary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"secondary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"tertiary"</div>
-                    <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"outline"</div>
-                </div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>"disabled"</div>
-            </Table.Cell>
-            <Table.Cell className="py-4">
-                <Select
-                        variant="outlined"
-                        rounded="lg"
-                        optionsList={{
-                            disabled: {
-                                label: 'elige una opcion',
-                                disabled: true
-                            },
-                            primary: {
-                                label: 'Primary'
-                            },
-                            secondary: {
-                                label: 'Secondary'
-                            },
-                            tertiary: {
-                                label: 'tertiary',
-                            }
-                        }}
-                    />
-            </Table.Cell>
-        </Table.Row>
-    </Table.Body>
-</Table>
+The Button component comes with several variant options, by default it uses the "primary" variant, but you can also use these: "disabled", "success", "primary", "secondary", "link",
+"ghost", "cancel", "danger", "outline", "outlineBlue", "outlineWhite", "outlineWhiteRed".
+
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100">
+    <ButtonGroup orientation="horizontal" gap={10} align="center">
+        <Button variant="primary">Primary</Button>
+        <Button variant="secondary">Secondary</Button>
+        <Button variant="success">Success</Button>
+        <Button variant="disabled">Disabled</Button>
+        <Button variant="danger">Danger</Button>
+        <Button variant="cancel">Cancel</Button>
+        <Button variant="ghost">Ghost</Button>
+        <Button variant="link">Link</Button>
+        <Button variant="outline">Outline</Button>
+        <Button variant="outlineBlue">OutlineBlue</Button>
+        <Button variant="outlineWhite">OutlineWhite</Button>
+        <Button variant="outlineWhiteRed">OutlineWhiteRed</Button>
+    </ButtonGroup>
+</Container>
+
+<WindowEditor
+    codeString="import { Button, ButtonGroup } from 'dd360-ds'
+
+    <ButtonGroup orientation='horizontal' gap={10} align='center'>
+    &nbsp;&nbsp;<Button variant='primary'>Primary</Button>
+    &nbsp;&nbsp;<Button variant='secondary'>Secondary</Button>
+    &nbsp;&nbsp;<Button variant='success'>Success</Button>
+    &nbsp;&nbsp;<Button variant='disabled'>Disabled</Button>
+    &nbsp;&nbsp;<Button variant='danger'>Danger</Button>
+    &nbsp;&nbsp;<Button variant='cancel'>Cancel</Button>
+    &nbsp;&nbsp;<Button variant='ghost'>Ghost</Button>
+    &nbsp;&nbsp;<Button variant='link'>Link</Button>
+    &nbsp;&nbsp;<Button variant='outline'>Outline</Button>
+    &nbsp;&nbsp;<Button variant='outlineBlue'>OutlineBlue</Button>
+    &nbsp;&nbsp;<Button variant='outlineWhite'>OutlineWhite</Button>
+    &nbsp;&nbsp;<Button variant='outlineWhiteRed'>OutlineWhiteRed</Button>
+    </ButtonGroup>"
+
+/>
+
+#### Loading
+
+To display the loading status, use the property isLoading.
+
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100 w-fit">
+    <Button isLoading>Click Me</Button>
+</Container>
+
+<WindowEditor
+    codeString="import { Button } from 'dd360-ds'
+
+    <Button isLoading>Click me</Button>"
+
+/>
+
+#### Disabled
+
+To disable a button, use the property disabled.
+
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100 w-fit">
+    <Button disabled>Click Me</Button>
+</Container>
+
+<WindowEditor
+    codeString="import { Button } from 'dd360-ds'
+
+    <Button disabled>Click me</Button>"
+
+/>
+
+#### Sizes
+
+Use the size property to change the size of the button. You can set the value to `small`, `medium`, `large`, or `extraLarge`.
+
+<Container className="py-5 px-3 rounded-md my-6 bg-gray-100">
+    <ButtonGroup orientation="horizontal" gap={10}>
+        <Button size="small">Small</Button>
+        <Button size="medium">Medium</Button>
+        <Button size="large">Large</Button>
+        <Button size="extraLarge">ExtraLarge</Button>
+    </ButtonGroup>
+</Container>
+
+<WindowEditor
+    codeString="import { Button, ButtonGroup } from 'dd360-ds'
+
+    <ButtonGroup orientation='horizontal' gap={10}>
+    &nbsp;&nbsp;<Button size='small'>Small</Button>
+    &nbsp;&nbsp;<Button size='medium'>Medium</Button>
+    &nbsp;&nbsp;<Button size='large'>Large</Button>
+    &nbsp;&nbsp;<Button size='extraLarge'>ExtraLarge</Button>
+    </ButtonGroup>"
+
+/>
+
+### API Reference
+
+<CustomTableDocs
+    dataTable={[
+        {
+            title: 'variant',
+            default: 'primary',
+            types: [
+                'disabled',
+                'success',
+                'primary',
+                'secondary',
+                'link',
+                'ghost',
+                'cancel',
+                'danger',
+                'outline',
+                'outlineBlue',
+                'outlineWhite',
+                'outlineWhiteRed'
+            ]
+        },
+        { title: 'disabled', default: 'false', types: ['boolean'] },
+        { title: 'isLoading', default: 'false', types: ['boolean'] },
+        { title: 'size', default: 'medium', types: ['small', 'medium', 'large', 'extraLarge'] },
+        { title: 'padding', default: null, types: ['string', 'number'] },
+        { title: 'paddingX', default: null, types: ['string', 'number'] },
+        { title: 'paddingY', default: null, types: ['string', 'number'] },
+        { title: 'rounded', default: null, types: ['string', 'number'] },
+        { title: 'className', default: null, types: ['string'] },
+        { title: 'role', default: null, types: ['string'] },
+        { title: 'renderLoading', default: null, types: ['object'] },
+        { title: '...', default: null, types: ['ButtonHTMLAttributes'] }
+    ]}
+/>

--- a/src/components/CustomTableDocs.tsx
+++ b/src/components/CustomTableDocs.tsx
@@ -1,0 +1,45 @@
+import { FC } from 'react'
+import { Table } from 'dd360-ds'
+
+interface Props {
+    dataTable: [{ title: string; default: string; types: []; required?: boolean }]
+}
+
+const CustomTableDocs: FC<Props> = ({ dataTable }) => {
+    return (
+        <Table className="my-5">
+            <Table.Header>
+                <Table.HeaderRow>
+                    <Table.HeaderCell style={{ minWidth: 150 }}>Name</Table.HeaderCell>
+                    <Table.HeaderCell style={{ minWidth: 150 }}>Types</Table.HeaderCell>
+                    <Table.HeaderCell style={{ minWidth: 150 }}>Default</Table.HeaderCell>
+                </Table.HeaderRow>
+            </Table.Header>
+            <Table.Body>
+                {dataTable.map((data) => (
+                    <Table.Row key={data.title}>
+                        <Table.Cell className="py-4">
+                            &quot;{data.title}&quot;{data.required && <span style={{ color: 'red', fontWeight: 'bold', fontSize: '14px' }}>*</span>}
+                        </Table.Cell>
+                        <Table.Cell className="py-4">
+                            <div className="flex align-center flex-wrap gap-2" style={{ width: 'fit-content' }}>
+                                {data.types?.map((type) => (
+                                    <div key={type} className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>
+                                        {type}
+                                    </div>
+                                ))}
+                            </div>
+                        </Table.Cell>
+                        <Table.Cell className="py-4">
+                            <div className="rounded-sm p-1 bg-gray-50 border border-gray-200 text-gray-500" style={{ width: 'fit-content' }}>
+                                {data.default ?? '-'}
+                            </div>
+                        </Table.Cell>
+                    </Table.Row>
+                ))}
+            </Table.Body>
+        </Table>
+    )
+}
+
+export default CustomTableDocs

--- a/src/components/WindowEditor.tsx
+++ b/src/components/WindowEditor.tsx
@@ -28,7 +28,7 @@ interface EditorProps {
 
 function WindowEditor({ codeString = cardMetricsString, language = 'tsx', className, header, style }: EditorProps) {
     return (
-        <div className={composeClasses('h-auto bg-gray-900 rounded-lg overflow-hidden', className)}>
+        <div className={composeClasses('h-auto bg-gray-900 rounded-lg overflow-hidden mt-2 mb-10', className)}>
             {header?.show && (
                 <nav className="flex items-center px-3 pt-2 gap-3 bg-gray-800">
                     <div className="flex items-center gap-2">

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,3 +7,4 @@ export { default as TestimonialsBanner } from '../modules/landing/TestimonialsBa
 export { default as ShowMore } from './ShowMore'
 export { default as DropdownExample } from '../modules/landing/DropdownExample'
 export { default as Badge } from './Badge'
+export { default as CustomTableDocs } from './CustomTableDocs'

--- a/src/utils/getComponents.tsx
+++ b/src/utils/getComponents.tsx
@@ -1,43 +1,46 @@
-import { Text } from 'dd360-ds'
 import { ReactNode } from 'react'
-import { WindowEditor } from '@/components'
 import * as Components from 'dd360-ds'
+import { Text } from 'dd360-ds'
+import DynamicHeroIcon from 'dd360-ds/DynamicHeroIcon';
+import { WindowEditor, CustomTableDocs } from '@/components'
 
 type Props = { children: ReactNode }
 
 export function getComponents() {
     return {
         h1: ({ children }: Props) => (
-            <Text variant="h1" className="mb-4" bold>
+            <Text variant="h1" className="mb-4 mt-2" bold>
                 {children}
             </Text>
         ),
         h2: ({ children }: Props) => (
-            <Text variant="h2" className="mb-4" bold>
+            <Text variant="h2" className="mb-4 mt-2" bold>
                 {children}
             </Text>
         ),
         h3: ({ children }: Props) => (
-            <Text variant="h3" className="mb-4" bold>
+            <Text variant="h3" className="mb-4 mt-2" bold>
                 {children}
             </Text>
         ),
         h4: ({ children }: Props) => (
-            <Text variant="h4" className="mb-4" bold>
+            <Text variant="h4" className="mb-4 mt-2" bold>
                 {children}
             </Text>
         ),
         h5: ({ children }: Props) => (
-            <Text variant="h5" className="mb-4" bold>
+            <Text variant="h5" className="mb-4 mt-2" bold>
                 {children}
             </Text>
         ),
         p: ({ children }: Props) => (
-            <Text variant="p" size="base" className="mb-4 text-gray-500 font-normal">
+            <Text variant="p" size="base" className="mb-4 mt-2 text-gray-500 font-normal">
                 {children}
             </Text>
         ),
         WindowEditor,
+        CustomTableDocs,
+        DynamicHeroIcon,
         ...Components
         // Add other custom components here as needed ---| Here |---
     }


### PR DESCRIPTION
## Summary

The documentation of the buttons was made.
Added a reusable component called CustomTableDocs to display the props with their values in each doc.

Structure docs:
![docs buttons](https://user-images.githubusercontent.com/127885606/226671455-6294b667-8646-44d1-9b04-21e11a84fb25.png)

## Task

[Jira task](https://dd360.atlassian.net/browse/CD-738?atlOrigin=eyJpIjoiNDZjZDRiODQyN2Y1NGYwMzlhMjc2N2MyMjg2NjI1ZDMiLCJwIjoiaiJ9)


## Affected sections

- docs\buttons\button-circle.mdx
- docs\buttons\button-group.mdx
- docs\buttons\button-radio-group.mdx
- docs\buttons\button-radio.mdx
- docs\buttons\button.mdx
- src\components\CustomTableDocs.tsx
- src\components\WindowEditor.tsx
- src\components\index.ts
- src\utils\getComponents.tsx

## How did you test this change?

- Manually
