### PR TITLE
[add] the theme configuration section

### DIFF
--- a/docs/get-started/getting-started.mdx
+++ b/docs/get-started/getting-started.mdx
@@ -28,6 +28,103 @@ ds library style sheet in your entry point, in this example we use React (App.js
 <WindowEditor language="javascript" header={{ show: true, title: 'App.js' }} codeString="import 'dd360-ds/dd360.css'" />
 
 <br />
+
+## <span name="floating-nav">Setup</span>
+For our library to work properly, you will need to wrap your application inside our Provider.
+
+Go to <span className="px-1 py-0.5 bg-pink-100 rounded-md">pages/_app.js</span> or <span className="px-1 py-0.5 bg-pink-100 rounded-md">pages/_app.tsx</span> (create it if it doesn't exist) and add this:
+
+### Next.js
+
+<WindowEditor language="typescript" codeString={`import { ThemeProvider } from 'dd360-ds/theme'
+import 'dd360-ds/dd360.css'
+
+export default function App({ Component, pageProps }: AppProps) {
+    return (
+        <ThemeProvider>
+            <Component {...pageProps} />
+        </ThemeProvider>
+    )
+}`} />
+
+### React.js
+
+Go to the root of your application and do this:
+
+<WindowEditor language="typescript" codeString={`import { ThemeProvider } from 'dd360-ds/theme'
+import 'dd360-ds/dd360.css'
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <StrictMode>
+    <ThemeProvider theme={theme}>
+      <App />
+    </ThemeProvider>
+  </StrictMode>
+);`} />
+
+
+## <span name="floating-nav">Customize theme (optional) 🎨👨‍🎨</span>
+
+ThemeProvider provides a simple way to customize the default themes, you can change the colors and fonts.
+
+To extend or override a token in the default theme, import the <span className="px-1 py-0.5 bg-pink-100 rounded-md">createTheme</span> function and add the keys you want to override. You can also add new values to the theme.
+
+For example, if you want to update your theme colors to include your brand colors, here's what to do:
+
+<WindowEditor language="typescript" codeString={`import { createTheme,  ThemeProvider, Text  } from "dd360-ds/theme" 
+import { Button } from "dd360-ds
+
+const theme = createTheme({
+  // // brand colors
+  palette: {
+    primary: {
+      contrastText: 'white',
+      main: '#1c4ed9'
+    },
+    secondary: {
+      main: 'white',
+      contrastText: ''
+    },
+    success: {
+      main: '#22c55e'
+    },
+    warning: {
+      main: '#eab308'
+    },
+    info: {
+      main: '#6b7280'
+    },
+    error: {
+      main: '#ef4444'
+    },
+    background: '#fff',
+    textColor: '#000'
+  },
+  typography: {
+    fontFamily: 'Rubik Pixels',
+    h1: { fontSize: 36 },
+    h2: { fontSize: 32 },
+    h3: { fontSize: 28 },
+    h4: { fontSize: 24 },
+    h5: { fontSize: 20 },
+    h6: { fontSize: 18 },
+    base: {
+      fontSize: 16
+    }
+  }
+
+  // 3. Pass the new theme to 'ThemeProvider'
+  <ThemeProvider theme={theme}>
+    <App />
+  </ThemeProvider>
+
+  // 4. Now you can use these colors in your components
+  function MyComponent() {
+    return <Button>Button primary</Button>
+  }
+})`} />
+
+<br />
 <br />
 ## <span name="floating-nav">Start Using the Library</span>
 

--- a/docs/get-started/getting-started.mdx
+++ b/docs/get-started/getting-started.mdx
@@ -36,7 +36,7 @@ Go to <span className="px-1 py-0.5 bg-pink-100 rounded-md">pages/_app.js</span> 
 
 ### Next.js
 
-<WindowEditor language="typescript" codeString={`import { ThemeProvider } from 'dd360-ds/theme'
+<WindowEditor language="tsx" codeString={`import { ThemeProvider } from 'dd360-ds/theme'
 import 'dd360-ds/dd360.css'
 
 export default function App({ Component, pageProps }: AppProps) {
@@ -51,12 +51,12 @@ export default function App({ Component, pageProps }: AppProps) {
 
 Go to the root of your application and do this:
 
-<WindowEditor language="typescript" codeString={`import { ThemeProvider } from 'dd360-ds/theme'
+<WindowEditor language="tsx" codeString={`import { ThemeProvider } from 'dd360-ds/theme'
 import 'dd360-ds/dd360.css'
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <ThemeProvider theme={theme}>
+    <ThemeProvider>
       <App />
     </ThemeProvider>
   </StrictMode>
@@ -71,7 +71,7 @@ To extend or override a token in the default theme, import the <span className="
 
 For example, if you want to update your theme colors to include your brand colors, here's what to do:
 
-<WindowEditor language="typescript" codeString={`import { createTheme,  ThemeProvider, Text  } from "dd360-ds/theme" 
+<WindowEditor language="tsx" codeString={`import { createTheme,  ThemeProvider, Text  } from "dd360-ds/theme" 
 import { Button } from "dd360-ds
 
 const theme = createTheme({


### PR DESCRIPTION
## Summary

The theme configuration section was added in the getting-starting file, this helps users to take advantage of the theme customization configuration

![localhost_3000_docs_get-started_getting-started](https://user-images.githubusercontent.com/31332180/231206777-0ec4c609-bce0-4ce1-85f9-feebe20f614d.png)

## Task

No Yet

## Affected sections

- docs/get-started/getting-started.mdx

## How did you test this change?

- Manually
