### PR TITLE
Feat(Documentation): add filter range and images documentation

### DIFF
--- a/docs/components/filter-range-slider.mdx
+++ b/docs/components/filter-range-slider.mdx
@@ -1,1 +1,220 @@
-filter range slider
+---
+product: dd360-ds
+title: React FilterRangeSlider component
+components: FilterRangeSlider
+---
+
+<br />
+<br />
+
+# <span name="floating-nav">Filter Range Slider</span>
+
+FilterRangeSlider is a customizable component that provides a 
+multi-range slider for filtering numeric values. The component displays 
+a dialog box that allows users to set a minimum and maximum value 
+range, and includes an "apply" and "reset" button to submit or clear 
+the values.
+
+<br />
+
+## <span name="floating-nav">Imports</span>
+
+<WindowEditor codeString="import { FilterRangeSlider } from 'dd360-ds'" />
+
+## <span name="floating-nav">Usage</span>
+
+To use the FilterRangeSlider component, import it into your React 
+application and include it in your JSX code. The component takes a 
+set of props to customize its behavior and appearance.
+
+<ContainerComponentDoc>
+  <FilterRangeSliderCustom />
+</ContainerComponentDoc>
+
+The code snippet below shows how to use the FilterRange component:
+
+<WindowEditor
+    codeString={`import { FilterRange } from 'dd360-ds''
+
+<FilterRangeSlider
+  title="Filter range slider name"
+  onApply={() => undefined}
+  onReset={() => undefined}
+  position={{
+      top: -160,
+      left: 0,
+      show: true
+  }}
+  max={100}
+  min={0}
+/>
+`}/>
+
+<br />
+
+#### <span name="floating-nav">Visibility & position</span>
+
+To manage the FilterRangeSlider component's visibility and position, you can use the
+useState hook in a functional component. Position stores the top and left
+coordinates, as well as a boolean indicating whether the component should be
+shown. The component listens for clicks on a button, which toggles the
+FilterRangeSlider's visibility and updates its position based on the click event's
+coordinates.
+
+<ContainerComponentDoc>
+  <FilterRangeSliderCustom onTop />
+</ContainerComponentDoc>
+
+The code snippet below shows how to handle the visibility and position:
+
+<WindowEditor
+    codeString={`import { FilterRangeSlider } from 'dd360-ds'
+
+const FilterComponent = () => {
+  const [domLoaded, setDomLoaded] = useState<boolean>(false)
+  const [position, setPosition] = useState<{
+    top: number
+    left: number
+    show: boolean
+  }>({
+    top: 0,
+    left: 0,
+    show: false
+  })
+
+useEffect(() => { setDomLoaded(true) }, [])
+
+return (
+    <>
+      {domLoaded && (
+        <div>
+          <button
+            className="flex items-center gap-1"
+            onClick={(event) => {
+              setPosition((position) => ({
+                top: event.pageY,
+                left: event.pageX,
+                show: !position.show
+              }))
+            }}
+          >
+            <Text size="lg" bold>
+              Filter range on top
+            </Text>
+            <DynamicHeroIcon icon="FilterIcon" className="w-4 h-4" />
+          </button>
+          <FilterRangeSlider
+            title="Filter range slider name"
+            onApply={() => undefined}
+            onReset={() => undefined}
+            max={100}
+            min={0}
+            position={{
+              top: position.top - 160,
+              left: position.left,
+              show: position.show
+            }}
+          />
+        </div>
+      )}
+    </>
+  )
+}
+
+export default FilterComponent
+ `}/>
+
+Note: The "domLoaded" state variable in the FilterComponent is used to ensure 
+that the component is fully rendered before displaying the FilterRangeSlider 
+component. This is important when using Next.js, as it performs server-side 
+rendering by default. By waiting for the client-side rendering to complete, 
+we can avoid any issues with the FilterRangeSlider component not being fully initialized.
+
+<br />
+
+#### <span name="floating-nav">Min & max</span>
+
+<span className='border border-gray-300 bg-gray-200 p-1'>min</span>
+Represents the minimum value that can be selected in the 
+range slider. It defaults to 0.
+
+<span className='border border-gray-300 bg-gray-200 p-1'>max</span>
+Represents the maximum value that can be selected in the 
+range slider. It defaults to 999999999.
+
+<span className='border border-gray-300 bg-gray-200 p-1'>initMinValue</span>
+Represents the initial minimum value that will be set 
+in the range slider. If it's not provided, then it will default to the min prop.
+
+<span className='border border-gray-300 bg-gray-200 p-1'>initMaxValue</span>
+Represents the initial maximum value that will be set 
+in the range slider. If it's not provided, then it will default to the max prop.
+
+<span className='border border-gray-300 bg-gray-200 p-1'>minValDisabled</span>
+Is a boolean value that determines whether the minimum 
+value input field will be disabled or not. If it's set to true, the minimum 
+input field will be disabled and the user will not be able to change its value. 
+It defaults to false.
+
+<span className='border border-gray-300 bg-gray-200 p-1'>maxValDisabled</span>
+Is a boolean value that determines whether the maximum 
+value input field will be disabled or not. If it's set to true, the maximum input 
+field will be disabled and the user will not be able to change its value. It 
+defaults to false.
+
+<ContainerComponentDoc>
+  <FilterRangeSliderCustom minMax />
+</ContainerComponentDoc>
+
+The code snippet below shows how to set a minimum and maximum value and disable the minimum value:
+
+<WindowEditor
+    codeString={`import { FilterRangeSlider } from 'dd360-ds'
+
+<FilterRangeSlider
+  title="Filter range slider name"
+  onApply={() => undefined}
+  onReset={() => undefined}
+  max={minMax ? 300 : 100}
+  min={minMax ? 150 : 0}
+  minValDisabled={true}
+  position={{
+    top: -160,
+    left: 0,
+    show: true
+  }}
+/>
+
+ `}/>
+
+<br />
+<br />
+
+## <span name="floating-nav">API Reference</span>
+
+<CustomTableDocs
+  dataTable={[
+    { title: 'title', default: null, types: ['string'] },
+    { title: 'min', default: '0', types: ['number'] },
+    { title: 'max', default: '999999999', types: ['number'] },
+    { title: 'initMinValue', default: null, types: ['number'] },
+    { title: 'initMaxValue', default: null, types: ['number'] },
+    { title: 'minValDisabled', default: null, types: ['boolean'] },
+    { title: 'maxValDisabled', default: null, types: ['boolean'] },
+    {
+      title: 'position',
+      default: '{ show: false, top: 0, left: 0 }',
+      types: ['{ show: boolean, top: number, left: number }']
+    },
+    { title: 'className', default: null, types: ['string'] },
+    { title: 'width', default: null, types: ['string'] },
+    { title: 'unitName', default: 'Km', types: ['string'] },
+    { title: 'textApplyBtn', default: 'Apply', types: ['string'] },
+    { title: 'textResetBtn', default: 'Reset', types: ['string'] },
+    { title: 'onApply', default: null, types: ['function'] },
+    { title: 'onReset', default: null, types: ['function'] }
+  ]}
+/>
+
+Note: This documentation assumes that the audience has basic knowledge of React
+and how to use components in React applications.

--- a/docs/components/filter-range.mdx
+++ b/docs/components/filter-range.mdx
@@ -1,1 +1,191 @@
-filter range
+---
+product: dd360-ds
+title: React FilterRange component
+components: FilterRange
+---
+
+<br />
+<br />
+
+# <span name="floating-nav">Filter Range</span>
+
+The FilterRange component allows users to filter a range of numeric values in an
+application. It has two numeric inputs for entering a minimum and maximum value,
+and can activate callback functions on both the "apply" and "reset" buttons.
+
+<br />
+
+## <span name="floating-nav">Imports</span>
+
+<WindowEditor codeString="import { FilterRange } from 'dd360-ds'" />
+
+## <span name="floating-nav">Usage</span>
+
+Use the FilterRange component as shown below:
+
+<ContainerComponentDoc>
+  <FilterRangeCustom />
+</ContainerComponentDoc>
+
+The code snippet below shows how to use the FilterRange component:
+
+<WindowEditor
+    codeString={`import { FilterRange } from 'dd360-ds''
+
+<FilterRange
+  onApply={() => console.log('Apply function')}
+  onReset={() => console.log('Reset function')}
+  position={{
+    top: 0,
+    left: 0,
+    show: true
+  }}
+  title="Filter range name"
+/>
+`}/>
+
+<br />
+
+#### <span name="floating-nav">Visibility & position</span>
+
+To manage the FilterRange component's visibility and position, you can use the
+useState hook in a functional component. Position stores the top and left
+coordinates, as well as a boolean indicating whether the component should be
+shown. The component listens for clicks on a button, which toggles the
+FilterRange's visibility and updates its position based on the click event's
+coordinates.
+
+<ContainerComponentDoc>
+  <FilterRangeCustom onTop />
+</ContainerComponentDoc>
+
+The code snippet below shows how to handle the visibility and position:
+
+<WindowEditor
+    codeString={`import { FilterRange } from 'dd360-ds'
+
+const FilterComponent = () => {
+  const [domLoaded, setDomLoaded] = useState<boolean>(false)
+  const [position, setPosition] = useState<{
+    top: number
+    left: number
+    show: boolean
+  }>({
+    top: 0,
+    left: 0,
+    show: false
+  })
+
+useEffect(() => { setDomLoaded(true) }, [])
+
+return (
+    <>
+      {domLoaded && (
+        <div>
+          <button
+            className="flex items-center gap-1"
+            onClick={(event) => {
+              setPosition((position) => ({
+                top: event.pageY,
+                left: event.pageX,
+                show: !position.show
+              }))
+            }}
+          >
+            <Text size="lg" bold>
+              Filter range on top
+            </Text>
+            <DynamicHeroIcon icon="FilterIcon" className="w-4 h-4" />
+          </button>
+          <FilterRange
+            max={300}
+            min={30}
+            onApply={() => undefined}
+            onReset={() => undefined}
+            position={{
+              top: position.top - 180,
+              left: position.left,
+              show: position.show
+            }}
+            title="Filter range name"
+          />
+        </div>
+      )}
+    </>
+  )
+}
+
+export default FilterComponent
+ `}/>
+
+Note: The "domLoaded" state variable in the FilterComponent is used to ensure 
+that the component is fully rendered before displaying the FilterRange 
+component. This is important when using Next.js, as it performs server-side 
+rendering by default. By waiting for the client-side rendering to complete, 
+we can avoid any issues with the FilterRange component not being fully initialized.
+
+<br />
+
+#### <span name="floating-nav">Min & max</span>
+
+The "min" and "max" values are used to set boundaries for the selected range, while
+the "defaultMin" and "defaultMax" values are used to set the initial values of the
+range when the FilterRange component is first opened. If the user enters a value 
+that is outside the specified range, an alert will be displayed when they click the
+"Apply" button. It is recommended to set sensible values for "min" and "max" to 
+avoid confusing the user. Also you can use the textMin and textMax properties to set
+a custom text in the FilterRange.
+
+<ContainerComponentDoc>
+  <FilterRangeCustom minMax />
+</ContainerComponentDoc>
+
+The code snippet below shows how to set a minimum and maximum value:
+
+<WindowEditor
+    codeString={`import { FilterRange } from 'dd360-ds'
+
+<FilterRange
+  max={100}
+  min={30}
+  onApply={() => undefined}
+  onReset={() => undefined}
+  title="Filter range name"
+  defaultMax={100}
+  defaultMin={30}
+  textMax='Custom max text'
+  textMin='Custom min text'
+/>
+
+ `}/>
+
+<br />
+<br />
+
+## <span name="floating-nav">API Reference</span>
+
+<CustomTableDocs
+  dataTable={[
+    { title: 'title', default: null, types: ['string'] },
+    { title: 'min', default: '0', types: ['number'] },
+    { title: 'max', default: '999999999', types: ['number'] },
+    { title: 'textMin', default: 'Minimum', types: ['string'] },
+    { title: 'textMax', default: 'Maximum', types: ['string'] },
+    { title: 'defaultMin', default: 'false', types: ['number'] },
+    { title: 'defaultMax', default: null, types: ['number'] },
+    { title: 'textApplyBtn', default: 'Apply', types: ['string'] },
+    { title: 'textResetBtn', default: 'Reset', types: ['string'] },
+    {
+      title: 'position',
+      default: '{ show: false, top: 0, left: 0 }',
+      types: ['{ show: boolean, top: number, left: number }']
+    },
+    { title: 'className', default: null, types: ['string'] },
+    { title: 'width', default: null, types: ['string'] },
+    { title: 'onApply', default: null, types: ['function'] },
+    { title: 'onReset', default: null, types: ['function'] }
+  ]}
+/>
+
+Note: This documentation assumes that the audience has basic knowledge of React
+and how to use components in React applications.

--- a/docs/images/avatar.mdx
+++ b/docs/images/avatar.mdx
@@ -1,1 +1,112 @@
-avatar page
+---
+product: dd360-ds
+title: React Avatar component
+components: Avatar
+---
+
+<br />
+<br />
+
+# <span name="floating-nav">Avatar</span>
+
+The Avatar component is a reusable component that can be used to render a full
+rounded image or a placeholder for an image. It provides the option to add
+children instead of an image for more flexibility. The component is particularly
+useful in scenarios where a user's profile picture needs to be displayed, or
+when an image needs to be used to represent an entity or an object.
+
+<br />
+
+## <span name="floating-nav">Imports</span>
+
+<WindowEditor codeString="import { Avatar } from 'dd360-ds'" />
+
+## <span name="floating-nav">Usage</span>
+
+The src and alt props are used to display an image inside the Avatar component.
+If these props are not provided, you can use the children prop to display custom
+content inside the Avatar, such as a text, an icon, or a combination of both.
+The children prop provides more flexibility than the src and alt props since it
+allows you to customize the Avatar's content further.
+
+Use the Avatar component as shown below:
+
+<ContainerComponentDoc>
+  <Avatar
+    alt="Avatar"
+    height="50px"
+    src="https://picsum.photos/50/50"
+    width="50px"
+  />
+</ContainerComponentDoc>
+
+The code snippet below shows how to use the Avatar component:
+
+<WindowEditor
+    codeString={`import { Avatar } from 'dd360-ds''
+
+<Avatar
+  alt="Avatar"
+  height="50px"
+  src="https://picsum.photos/50/50"
+  width="50px"
+/>
+`}/>
+
+<br />
+
+#### <span name="floating-nav">Without image</span>
+
+In this example, the Avatar component is used to display a custom text instead
+of an image. Instead of providing an image through the src prop, the children
+prop is used to provide the custom content.
+
+<ContainerComponentDoc>
+  <Avatar
+    style={{
+      backgroundColor: 'red',
+      color: 'white',
+      height: '50px',
+      width: '50px'
+    }}
+  >
+    <Text variant="span">TB</Text>
+  </Avatar>
+</ContainerComponentDoc>
+
+The code snippet below shows how to set a Avatar component without image:
+
+<WindowEditor
+    codeString={`import { Avatar } from 'dd360-ds''
+
+<Avatar
+  style={{
+    backgroundColor: 'red',
+    color: 'white',
+    height: '50px',
+    width: '50px'
+  }}
+>
+  <Text variant="span">TB</Text>
+</Avatar>
+`}/>
+
+<br />
+<br />
+
+## <span name="floating-nav">API Reference</span>
+
+<CustomTableDocs
+  dataTable={[
+    { title: 'children', default: null, types: ['ReactNode'] },
+    { title: 'src', default: null, types: ['string'] },
+    { title: 'alt', default: null, types: ['string'] },
+    { title: 'width', default: null, types: ['string'] },
+    { title: 'height', default: null, types: ['string'] },
+    { title: 'className', default: null, types: ['string'] },
+    { title: 'style', default: null, types: ['CSSProperties'] }
+  ]}
+/>
+
+Note: This documentation assumes that the audience has basic knowledge of React
+and how to use components in React applications.

--- a/docs/images/image-icon.mdx
+++ b/docs/images/image-icon.mdx
@@ -1,1 +1,88 @@
-imagen icon page
+---
+product: dd360-ds
+title: React ImageIcon component
+components: ImageIcon
+---
+
+<br />
+<br />
+
+# <span name="floating-nav">ImageIcon</span>
+
+The ImageIcon component allows you display an image icon. It can be used as a
+standalone image or as a button with an onClick function.
+
+<br />
+
+## <span name="floating-nav">Imports</span>
+
+<WindowEditor codeString="import { ImageIcon } from 'dd360-ds'" />
+
+## <span name="floating-nav">Usage</span>
+
+To use the ImageIcon component, you can import it into your app and render it
+with the desired props. Here's an example:
+
+<ContainerComponentDoc>
+  <ImageIcon src="https://picsum.photos/200/300?grayscale" />
+</ContainerComponentDoc>
+
+The code snippet below shows how to use the ImageIcon component:
+
+<WindowEditor
+    codeString={`import { ImageIcon } from 'dd360-ds''
+
+<ImageIcon src="https://picsum.photos/200/300?grayscale" />
+`}/>
+
+<br />
+
+#### <span name="floating-nav">ImageIcon as a button</span>
+
+You can use the prop button to render the ImageIcon as a button. A boolean
+indicating whether the ImageIcon should be rendered as a button or not. When
+button is true, the ImageIcon is wrapped in a button element.
+
+The buttonOnClick property receives the function to be called when the button is
+clicked. This prop is only used when button is true.
+
+<ContainerComponentDoc className="flex gap-2">
+  <ImageIcon
+    button
+    buttonOnClick={() => {}}
+    src="https://picsum.photos/200/300?grayscale"
+  />
+</ContainerComponentDoc>
+
+The code snippet below shows how to set a ImageIcon component as a button and
+how to call the function when the button is clicked:
+
+<WindowEditor
+    codeString={`import { ImageIcon } from 'dd360-ds''
+
+<ImageIcon
+  button
+  buttonOnClick={() => {}}
+  src="https://picsum.photos/200/300?grayscale"
+/>
+`}/>
+
+<br />
+<br />
+
+## <span name="floating-nav">API Reference</span>
+
+<CustomTableDocs
+  dataTable={[
+    { title: 'src', default: null, types: ['string'] },
+    { title: 'alt', default: null, types: ['string'] },
+    { title: 'width', default: null, types: ['string'] },
+    { title: 'height', default: null, types: ['string'] },
+    { title: 'className', default: null, types: ['string'] },
+    { title: 'button', default: 'false', types: ['boolean'] },
+    { title: 'buttonOnClick', default: null, types: ['function'] }
+  ]}
+/>
+
+Note: This documentation assumes that the audience has basic knowledge of React
+and how to use components in React applications.

--- a/docs/images/image.mdx
+++ b/docs/images/image.mdx
@@ -1,1 +1,110 @@
-image page
+---
+product: dd360-ds
+title: React Image component
+components: Image
+---
+
+<br />
+<br />
+
+# <span name="floating-nav">Image</span>
+
+The Image component is a reusable component that provides a simple way to
+display images on your website. It allows you to customize the appearance of the
+image, such as its size, and rounded corners.
+
+<br />
+
+## <span name="floating-nav">Imports</span>
+
+<WindowEditor codeString="import { Image } from 'dd360-ds'" />
+
+## <span name="floating-nav">Usage</span>
+
+To use the Image component, you can import it into your app and render it with
+the desired props. Here's an example:
+
+<ContainerComponentDoc>
+  <Image src="https://picsum.photos/200/300?grayscale" />
+</ContainerComponentDoc>
+
+The code snippet below shows how to use the Image component:
+
+<WindowEditor
+    codeString={`import { Image } from 'dd360-ds''
+
+<Image src="https://picsum.photos/200/300?grayscale" />
+`}/>
+
+<br />
+
+#### <span name="floating-nav">Rounded</span>
+
+The rounded prop is an optional string that specifies the level of rounding to
+apply to the image corners. The possible values are 'sm', 'md', and 'lg'. By
+default, the rounded prop is set to 'lg'.
+
+<ContainerComponentDoc className="flex gap-2">
+  <Image
+    src="https://picsum.photos/100?grayscale"
+    width="100px"
+    height="100px"
+    rounded="sm"
+  />
+  <Image
+    src="https://picsum.photos/100?grayscale"
+    width="100px"
+    height="100px"
+    rounded="md"
+  />
+  <Image
+    src="https://picsum.photos/100?grayscale"
+    width="100px"
+    height="100px"
+    rounded="lg"
+  />
+</ContainerComponentDoc>
+
+The code snippet below shows how to set a Avatar component without image:
+
+<WindowEditor
+    codeString={`import { Image } from 'dd360-ds''
+
+<Image
+  src="https://picsum.photos/100?grayscale"
+  width="100px"
+  height="100px"
+  rounded="sm"
+/>
+<Image
+  src="https://picsum.photos/100?grayscale"
+  width="100px"
+  height="100px"
+  rounded="md"
+/>
+<Image
+  src="https://picsum.photos/100?grayscale"
+  width="100px"
+  height="100px"
+  rounded="lg"
+/>
+`}/>
+
+<br />
+<br />
+
+## <span name="floating-nav">API Reference</span>
+
+<CustomTableDocs
+  dataTable={[
+    { title: 'src', default: null, types: ['string'] },
+    { title: 'alt', default: null, types: ['string'] },
+    { title: 'width', default: null, types: ['string'] },
+    { title: 'height', default: null, types: ['string'] },
+    { title: 'className', default: null, types: ['string'] },
+    { title: 'rounded', default: 'lg', types: ['sm', 'md', 'lg'] }
+  ]}
+/>
+
+Note: This documentation assumes that the audience has basic knowledge of React
+and how to use components in React applications.

--- a/src/components/docs/components/FilterRangeCustom.tsx
+++ b/src/components/docs/components/FilterRangeCustom.tsx
@@ -2,7 +2,13 @@ import { useEffect, useState } from 'react'
 import { FilterRange, Text } from 'dd360-ds'
 import DynamicHeroIcon from 'dd360-ds/DynamicHeroIcon'
 
-const FilterRangeCustom = ({ onTop, minMax }: { onTop: boolean, minMax: boolean }) => {
+const FilterRangeCustom = ({
+  onTop,
+  minMax
+}: {
+  onTop: boolean
+  minMax: boolean
+}) => {
   const [domLoaded, setDomLoaded] = useState<boolean>(false)
   const [position, setPosition] = useState<{
     top: number

--- a/src/components/docs/components/FilterRangeCustom.tsx
+++ b/src/components/docs/components/FilterRangeCustom.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react'
+import { FilterRange, Text } from 'dd360-ds'
+import DynamicHeroIcon from 'dd360-ds/DynamicHeroIcon'
+
+const FilterRangeCustom = ({ onTop, minMax }: { onTop: boolean, minMax: boolean }) => {
+  const [domLoaded, setDomLoaded] = useState<boolean>(false)
+  const [position, setPosition] = useState<{
+    top: number
+    left: number
+    show: boolean
+  }>({
+    top: 0,
+    left: 0,
+    show: false
+  })
+
+  useEffect(() => {
+    setDomLoaded(true)
+  }, [])
+
+  return (
+    <>
+      {domLoaded && (
+        <div>
+          <button
+            className="flex items-center gap-1"
+            onClick={(event) => {
+              setPosition((position) => ({
+                top: event.pageY,
+                left: event.pageX,
+                show: !position.show
+              }))
+            }}
+          >
+            <Text size="lg" bold>
+              {onTop ? 'Filter range on top' : 'Filter range'}
+            </Text>
+            <DynamicHeroIcon icon="FilterIcon" className="w-4 h-4" />
+          </button>
+          <FilterRange
+            max={minMax ? 100 : 0}
+            min={minMax ? 30 : 0}
+            onApply={() => undefined}
+            onReset={() => undefined}
+            position={{
+              top: position.top + (onTop ? -180 : 40),
+              left: position.left,
+              show: position.show
+            }}
+            title="Filter range name"
+            defaultMax={minMax ? 100 : 0}
+            defaultMin={minMax ? 30 : 0}
+            textMax={minMax ? 'Custom max text' : 'Maximum'}
+            textMin={minMax ? 'Custom min text' : 'Minimum'}
+          />
+        </div>
+      )}
+    </>
+  )
+}
+
+export default FilterRangeCustom

--- a/src/components/docs/components/FilterRangeSliderCustom.tsx
+++ b/src/components/docs/components/FilterRangeSliderCustom.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react'
+import { FilterRangeSlider, Text } from 'dd360-ds'
+import DynamicHeroIcon from 'dd360-ds/DynamicHeroIcon'
+
+const FilterRangeSliderCustom = ({ onTop, minMax }: { onTop: boolean, minMax: boolean }) => {
+  const [domLoaded, setDomLoaded] = useState<boolean>(false)
+  const [position, setPosition] = useState<{
+    top: number
+    left: number
+    show: boolean
+  }>({
+    top: 0,
+    left: 0,
+    show: false
+  })
+
+  useEffect(() => {
+    setDomLoaded(true)
+  }, [])
+
+  return (
+    <>
+      {domLoaded && (
+        <div>
+          <button
+            className="flex items-center gap-1"
+            onClick={(event) => {
+              setPosition((position) => ({
+                top: event.pageY,
+                left: event.pageX,
+                show: !position.show
+              }))
+            }}
+          >
+            <Text size="lg" bold>
+              {onTop ? 'Filter range on top' : 'Filter range'}
+            </Text>
+            <DynamicHeroIcon icon="FilterIcon" className="w-4 h-4" />
+          </button>
+          <FilterRangeSlider
+            title="Filter range slider name"
+            onApply={() => undefined}
+            onReset={() => undefined}
+            position={{
+              top: position.top + (onTop ? -160 : 40),
+              left: position.left,
+              show: position.show
+            }}
+            max={minMax ? 300 : 100}
+            min={minMax ? 150 : 0}
+            minValDisabled={minMax}
+          />
+        </div>
+      )}
+    </>
+  )
+}
+
+export default FilterRangeSliderCustom

--- a/src/components/docs/components/FilterRangeSliderCustom.tsx
+++ b/src/components/docs/components/FilterRangeSliderCustom.tsx
@@ -2,7 +2,13 @@ import { useEffect, useState } from 'react'
 import { FilterRangeSlider, Text } from 'dd360-ds'
 import DynamicHeroIcon from 'dd360-ds/DynamicHeroIcon'
 
-const FilterRangeSliderCustom = ({ onTop, minMax }: { onTop: boolean, minMax: boolean }) => {
+const FilterRangeSliderCustom = ({
+  onTop,
+  minMax
+}: {
+  onTop: boolean
+  minMax: boolean
+}) => {
   const [domLoaded, setDomLoaded] = useState<boolean>(false)
   const [position, setPosition] = useState<{
     top: number

--- a/src/components/docs/components/index.ts
+++ b/src/components/docs/components/index.ts
@@ -1,0 +1,3 @@
+export { default as CustomCallout } from './CustomCallout'
+export { default as FilterRangeCustom } from './FilterRangeCustom'
+export { default as FilterRangeSliderCustom } from './FilterRangeSliderCustom'

--- a/src/utils/getComponents.tsx
+++ b/src/utils/getComponents.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/components/docs/modals'
 
 import SwitchCustom from '@/components/docs/controls/SwitchCustom'
-import CustomCallout from '@/components/docs/components/CustomCallout'
+import { CustomCallout, FilterRangeCustom, FilterRangeSliderCustom } from '@/components/docs/components'
 
 type Props = { children: ReactNode }
 
@@ -67,6 +67,8 @@ export function getComponents() {
     FileViewerCustom,
     AsideModalCustom,
     CustomCallout,
+    FilterRangeCustom,
+    FilterRangeSliderCustom,
     ...Components
     // Add other custom components here as needed ---| Here |---
   }

--- a/src/utils/getComponents.tsx
+++ b/src/utils/getComponents.tsx
@@ -16,7 +16,11 @@ import {
 } from '@/components/docs/modals'
 
 import SwitchCustom from '@/components/docs/controls/SwitchCustom'
-import { CustomCallout, FilterRangeCustom, FilterRangeSliderCustom } from '@/components/docs/components'
+import {
+  CustomCallout,
+  FilterRangeCustom,
+  FilterRangeSliderCustom
+} from '@/components/docs/components'
 
 type Props = { children: ReactNode }
 


### PR DESCRIPTION
## Summary

Add documentation to
- FilterRange
- FilterRangeSlider
- Image
- ImageIcon
- Avatar

## Task

- https://dd360.atlassian.net/browse/CD-991
- https://dd360.atlassian.net/browse/CD-1011

## Affected sections

- docs/components/filter-range-slider.mdx
- docs/components/filter-range.mdx
- docs/images/avatar.mdx
- docs/images/image-icon.mdx
- docs/images/image.mdx
- src/components/docs/components/FilterRangeCustom.tsx
- src/components/docs/components/FilterRangeSliderCustom.tsx
- src/components/docs/components/index.ts

## How did you test this change?

- Manually
